### PR TITLE
keep error message on focus

### DIFF
--- a/build/vendor/jquery-bootstrap-validation/js/jqBootstrapValidation.js
+++ b/build/vendor/jquery-bootstrap-validation/js/jqBootstrapValidation.js
@@ -413,7 +413,7 @@
               var errorsFound = [];
 
               $.each(validators, function (validatorType, validatorTypeArray) {
-                if (value || value.length || (params && params.includeEmpty) || (!!settings.validatorTypes[validatorType].blockSubmit && params && !!params.submitting)) {
+                if (value || value.length || (params && params.includeEmpty) || (!!settings.validatorTypes[validatorType].blockSubmit)) {
                   $.each(validatorTypeArray, function (i, validator) {
                     if (settings.validatorTypes[validatorType].validate($this, value, validator)) {
                       errorsFound.push(validator.message);


### PR DESCRIPTION
modify library in a way that it always show validation errors even if the from is not yet submitted,
because in case a input field gets the focus after a error, the validation was removing the error message.

this is a alternative fix to https://github.com/OXID-eSales/wave-theme/pull/45
I did not compare the solutions yet so any feedback is welcome

WARNING before merge:

- js must be compiled
- tmpl cleanup of duplicate jsinclusion should be done before because some templates include a minified version of that library in combination with the embedded:
  - https://github.com/OXID-eSales/wave-theme/blob/master/tpl/page/checkout/payment.tpl#L87
  - https://github.com/OXID-eSales/wave-theme/blob/master/tpl/form/contact.tpl#L1
  - https://github.com/OXID-eSales/wave-theme/blob/master/tpl/form/user.tpl#L1
  - https://github.com/OXID-eSales/wave-theme/blob/master/tpl/form/user_checkout_change.tpl#L1
  - https://github.com/OXID-eSales/wave-theme/blob/master/tpl/page/checkout/payment.tpl#L87 
  so you have to remove all that lines because in https://github.com/OXID-eSales/wave-theme/blob/98cbfafdb4a4e5b6e3539fe9e50bff04c2d885f8/Gruntfile.js#L80 the lib is merged into script.min.js
