### PR TITLE
Don't display "products per page" if there's only one option

### DIFF
--- a/tpl/widget/locator/itemsperpage.tpl
+++ b/tpl/widget/locator/itemsperpage.tpl
@@ -1,21 +1,23 @@
 [{assign var="_additionalParams" value=$oView->getAdditionalParams()}]
 [{assign var="listType" value=$oView->getListDisplayType()}]
 
-<div class="btn-group">
-    <button type="button" class="btn btn-outline-dark btn-sm dropdown-toggle" data-toggle="dropdown">
-        <strong>[{oxmultilang ident="PRODUCTS_PER_PAGE"}]</strong>
-        [{if $oViewConf->getArtPerPageCount()}]
-            [{$oViewConf->getArtPerPageCount()}]
-        [{else}]
-            [{oxmultilang ident="CHOOSE"}]
-        [{/if}]
-        <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-        [{foreach from=$oViewConf->getNrOfCatArticles() item=iItemsPerPage}]
-            <li class="filter-item[{if $oViewConf->getArtPerPageCount() == $iItemsPerPage}] selected[{/if}]">
-                <a href="[{$oView->getLink()|oxaddparams:"ldtype=$listType&amp;_artperpage=$iItemsPerPage&amp;pgNr=0&amp;$_additionalParams"}]" class="filter-link[{if $oViewConf->getArtPerPageCount() == $iItemsPerPage}] selected[{/if}]">[{$iItemsPerPage}]</a>
-            </li>
-        [{/foreach}]
-    </ul>
-</div>
+[{if $oViewConf->getNrOfCatArticles()|@count > 1}]
+    <div class="btn-group">
+        <button type="button" class="btn btn-outline-dark btn-sm dropdown-toggle" data-toggle="dropdown">
+            <strong>[{oxmultilang ident="PRODUCTS_PER_PAGE"}]</strong>
+            [{if $oViewConf->getArtPerPageCount()}]
+                [{$oViewConf->getArtPerPageCount()}]
+            [{else}]
+                [{oxmultilang ident="CHOOSE"}]
+            [{/if}]
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            [{foreach from=$oViewConf->getNrOfCatArticles() item=iItemsPerPage}]
+                <li class="filter-item[{if $oViewConf->getArtPerPageCount() == $iItemsPerPage}] selected[{/if}]">
+                    <a href="[{$oView->getLink()|oxaddparams:"ldtype=$listType&amp;_artperpage=$iItemsPerPage&amp;pgNr=0&amp;$_additionalParams"}]" class="filter-link[{if $oViewConf->getArtPerPageCount() == $iItemsPerPage}] selected[{/if}]">[{$iItemsPerPage}]</a>
+                </li>
+            [{/foreach}]
+        </ul>
+    </div>
+[{/if}]


### PR DESCRIPTION
It doesn't make much sense to display the "products per page" selector if it has only one option anyway. I added an if-statement to itemsperpage.tpl to check whether that's the case.

As a bonus, this gives admins the option turn off this feature in the backend if they don't want it - just reduce the number of options to one an it's gone. Since getNrOfCatArticles() can be different for gallery and line listings, you can even turn it off selectively for either one.