### PR TITLE
keys removed in DE but haven't been removed in EN

### DIFF
--- a/en/theme_options.php
+++ b/en/theme_options.php
@@ -191,8 +191,6 @@ $aLang = array(
     'SHOP_THEME_blSliderShowImageCaption'           => 'Activate captions for slider on home page',
     'HELP_SHOP_THEME_blSliderShowImageCaption'      => 'A caption is visible, when the active slide has an assigned product.',
 
-    'SHOP_THEME_sEcondaAccountId'                   => 'econda-ID',
-    'HELP_SHOP_THEME_sEcondaAccountId'              => 'Please enter your econda ID.<br>Format: XXXXXXXX-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX-X.<br>Please keep in mind to activate the econda Webshop Controlling in your shop.',
     'SHOP_THEME_blEcondaRecommendationsStart'       => 'Show recommendations on home page',
     'SHOP_THEME_sEcondaWidgetIdStart'               => 'Recommendation-Widget-ID für Startseite',
     'SHOP_THEME_blEcondaRecommendationsList'        => 'Show recommendations in listings',


### PR DESCRIPTION
Apparently, the lang keys 'HELP_SHOP_THEME_sEcondaAccountId' and 'SHOP_THEME_sEcondaAccountId' have been removed in https://github.com/OXID-eSales/wave-theme/blob/master/en/theme_options.php#L194 and #L195 from DE lang file but never from EN lang file. Actually the same goes for Flow Theme. This PR shall resolve it.