### PR TITLE
Remove fixed font-size of btn-sm

### DIFF
--- a/build/scss/widget/locator/_paging.scss
+++ b/build/scss/widget/locator/_paging.scss
@@ -35,7 +35,3 @@
     white-space: nowrap;
   }
 }
-
-.btn-sm {
-  font-size: 12px;
-}


### PR DESCRIPTION
There is no justifiable way this should be fixed and even less why it should be here.