### PR TITLE
Simplify checkout (user registration)

### DIFF
--- a/de/lang.php
+++ b/de/lang.php
@@ -111,7 +111,7 @@ $aLang = array(
     'DD_BASKET_BACK_TO_SHOP'                                => 'zurück zum Shop',
 
     // E-Mails
-    'DD_FOOTER_FOLLOW_US'                                    => 'Folgen Sie uns',
+    'DD_FOOTER_FOLLOW_US'                                   => 'Folgen Sie uns',
     'DD_FORGOT_PASSWORD_HEADING'                            => 'Passwort vergessen',
     'DD_INVITE_HEADING'                                     => 'Artikel-Empfehlung',
     'DD_INVITE_LINK'                                        => 'Link',

--- a/tpl/form/fieldset/user_account.tpl
+++ b/tpl/form/fieldset/user_account.tpl
@@ -1,12 +1,14 @@
-<div class="form-group row[{if $aErrors.oxuser__oxusername}] oxInValid[{/if}]">
-    [{block name="user_account_username"}]
-        <label class="col-lg-3 req" for="userLoginName">[{oxmultilang ident="EMAIL_ADDRESS"}]</label>
-        <div class="col-lg-9">
-            <input id="userLoginName" class="form-control js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="lgn_usr" value="[{$oView->getActiveUsername()}]" required="required">
-            <div class="help-block"></div>
-        </div>
-    [{/block}]
-</div>
+[{if $context != 'checkout'}]
+    <div class="form-group row[{if $aErrors.oxuser__oxusername}] oxInValid[{/if}]">
+        [{block name="user_account_username"}]
+            <label class="col-lg-3 req" for="userLoginName">[{oxmultilang ident="EMAIL_ADDRESS"}]</label>
+            <div class="col-lg-9">
+                <input id="userLoginName" class="form-control js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="lgn_usr" value="[{$oView->getActiveUsername()}]" required="required">
+                <div class="help-block"></div>
+            </div>
+        [{/block}]
+    </div>
+[{/if}]
 <div class="form-group row[{if $aErrors.oxuser__oxpassword}] oxInValid[{/if}]">
     [{block name="user_account_password"}]
         <label class="col-lg-3 req" for="userPassword">[{oxmultilang ident="PASSWORD"}]</label>
@@ -26,16 +28,3 @@
         </div>
     [{/block}]
 </div>
-[{block name="user_account_newsletter"}]
-    <div class="form-group row">
-        <div class="col-lg-9 offset-lg-3">
-            <input type="hidden" name="blnewssubscribed" value="0">
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" name="blnewssubscribed" value="1" [{if $oView->isNewsSubscribed()}]checked[{/if}]> [{oxmultilang ident="NEWSLETTER_SUBSCRIPTION"}]
-                </label>
-            </div>
-            <span class="help-block">[{oxmultilang ident="MESSAGE_NEWSLETTER_SUBSCRIPTION"}]</span>
-        </div>
-    </div>
-[{/block}]

--- a/tpl/form/fieldset/user_billing.tpl
+++ b/tpl/form/fieldset/user_billing.tpl
@@ -152,6 +152,17 @@
     </div>
 [{/block}]
 
+[{if $context == 'checkout'}]
+    <div class="form-group row[{if $aErrors.oxuser__oxusername}] oxInValid[{/if}]">
+        [{block name="user_account_username"}]
+            <label class="col-lg-3 req" for="userLoginName">[{oxmultilang ident="EMAIL_ADDRESS"}]</label>
+            <div class="col-lg-9">
+                <input id="userLoginName" class="form-control js-oxValidate js-oxValidate_notEmpty js-oxValidate_email" type="email" name="lgn_usr" value="[{$oView->getActiveUsername()}]" required="required">
+                <div class="help-block"></div>
+            </div>
+        [{/block}]
+    </div>
+[{/if}]
 <div class="form-group row[{if $aErrors.oxuser__oxfon}] text-danger"[{/if}]">
     <label class="col-lg-3[{if $oView->isFieldRequired(oxuser__oxfon)}] req[{/if}]" for="invadr_oxuser__oxfon">[{oxmultilang ident="PHONE"}]</label>
     <div class="col-lg-9">

--- a/tpl/form/fieldset/user_shipping.tpl
+++ b/tpl/form/fieldset/user_shipping.tpl
@@ -86,7 +86,7 @@
 <div id="shippingAddressForm" [{if $delivadr}]style="display: none;"[{/if}]>
     <div class="form-group">
         <label class="control-label col-lg-3[{if $oView->isFieldRequired(oxaddress__oxsal)}] req[{/if}]" for="deladr_oxaddress__oxsal">[{oxmultilang ident="TITLE"}]</label>
-        <div class="col-lg-2">
+        <div class="col-lg-9">
             [{include file="form/fieldset/salutation.tpl" name="deladr[oxaddress__oxsal]" value=$delivadr->oxaddress__oxsal->value value2=$deladr.oxaddress__oxsal class="form-control" id="deladr_oxaddress__oxsal"}]
             <div class="help-block"></div>
         </div>

--- a/tpl/form/login.tpl
+++ b/tpl/form/login.tpl
@@ -1,6 +1,6 @@
 [{oxscript include="js/libs/jqBootstrapValidation.min.js" priority=10}]
 [{oxscript add="$('input,select,textarea').not('[type=submit]').jqBootstrapValidation();"}]
-<div class="card">
+<div class="card" style="height:auto">
     <form class="js-oxValidate" id="optionLogin" name="login" action="[{$oViewConf->getSslSelfLink()}]" method="post" role="form" novalidate="novalidate">
 
         <div class="card-header">

--- a/tpl/form/user_checkout_change.tpl
+++ b/tpl/form/user_checkout_change.tpl
@@ -115,6 +115,11 @@
                                 [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true onChangeClass='user'}]
                             </div>
                         [{/block}]
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-body">
                         [{block name="user_checkout_shipping_feedback"}]
                             [{include file="form/fieldset/order_newsletter.tpl" blSubscribeNews=true}]
                             [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]

--- a/tpl/form/user_checkout_registration.tpl
+++ b/tpl/form/user_checkout_registration.tpl
@@ -21,7 +21,23 @@
         [{/strip}]
     [{/capture}]
 
+    [{capture assign="noRegistrationJS"}]
+        [{strip}]
+        $("#noRegistration").click(function () {
+            $("#passwordFields").toggle();
+            if ($("#noRegistration").prop("checked")) {
+                $("#registrationOption").val(1);
+                $("#userPassword").val('');
+                $("#userPasswordConfirm").val('');
+            } else {
+                $("#kontooption").val(3);
+            }
+        });
+        [{/strip}]
+    [{/capture}]
+
     [{oxscript add=$sValidationJS}]
+    [{oxscript add=$noRegistrationJS}]
 
     [{assign var="aErrors" value=$oView->getFieldValidationErrors()}]
 
@@ -31,7 +47,7 @@
                 [{$oViewConf->getHiddenSid()}]
                 [{$oViewConf->getNavFormParams()}]
                 <input type="hidden" name="cl" value="user">
-                <input type="hidden" name="option" value="3">
+                <input type="hidden" name="option" id="registrationOption" value="3">
                 [{if !$oxcmp_user->oxuser__oxpassword->value}]
                     <input type="hidden" name="fnc" value="createuser">
                 [{else}]
@@ -42,29 +58,32 @@
                 <input type="hidden" name="blshowshipaddress" value="1">
             </div>
 
-            [{block name="user_checkout_registration_next_step_top"}]
-                <div class="card bg-light cart-buttons">
-                    <div class="card-body">
-                        <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-outline-dark prevStep submitButton largeButton" id="userBackStepTop">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
-                    </div>
-                </div>
-            [{/block}]
-
             <div class="checkoutCollumns clear">
-                <div class="card">
-                    <div class="card-header">
-                        <h3 class="card-title">[{oxmultilang ident="ACCOUNT_INFORMATION"}]</h3>
-                    </div>
-                    <div class="card-body">
-                        [{include file="form/fieldset/user_account.tpl"}]
-                    </div>
-                </div>
                 <div class="card">
                     <div class="card-header">
                         <h3 class="card-title">[{oxmultilang ident="BILLING_ADDRESS"}]</h3>
                     </div>
                     <div class="card-body">
-                        [{include file="form/fieldset/user_billing.tpl" noFormSubmit=true blSubscribeNews=false blOrderRemark=true}]
+                        [{include file="form/fieldset/user_billing.tpl" noFormSubmit=true blSubscribeNews=false blOrderRemark=true context="checkout"}]
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">[{oxmultilang ident="ACCOUNT_INFORMATION"}]</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="form-group">
+                            <div class="col-lg-9 offset-lg-3">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="noregistration" id="noRegistration"> [{oxmultilang ident="PURCHASE_WITHOUT_REGISTRATION"}]
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="passwordFields">
+                            [{include file="form/fieldset/user_account.tpl" context="checkout"}]
+                        </div>
                     </div>
                 </div>
 
@@ -86,9 +105,25 @@
                         <div id="shippingAddress" [{if !$oView->showShipAddress()}]style="display: none;"[{/if}]>
                             [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true}]
                         </div>
+                    </div>
+                </div>
 
+                <div class="card">
+                    <div class="card-body">
+                        [{block name="user_account_newsletter"}]
+                            <div class="form-group row">
+                                <div class="col-lg-9 offset-lg-3">
+                                    <input type="hidden" name="blnewssubscribed" value="0">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="blnewssubscribed" value="1" [{if $oView->isNewsSubscribed()}]checked[{/if}]> [{oxmultilang ident="NEWSLETTER_SUBSCRIPTION"}]
+                                        </label>
+                                    </div>
+                                    <span class="help-block">[{oxmultilang ident="MESSAGE_NEWSLETTER_SUBSCRIPTION"}]</span>
+                                </div>
+                            </div>
+                        [{/block}]
                         [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]
-
                     </div>
                 </div>
             </div>

--- a/tpl/page/checkout/user.tpl
+++ b/tpl/page/checkout/user.tpl
@@ -3,30 +3,35 @@
 
     [{* ordering steps *}]
     [{include file="page/checkout/inc/steps.tpl" active=2}]
-
-    [{block name="checkout_user_main"}]
-        [{if !$oxcmp_user && !$oView->getLoginOption()}]
-            [{include file="page/checkout/inc/options.tpl"}]
-        [{/if}]
-
-        [{block name="checkout_user_noregistration"}]
-            [{if !$oxcmp_user && $oView->getLoginOption() == 1}]
-                [{include file="form/user_checkout_noregistration.tpl"}]
-            [{/if}]
+    [{if !$oxcmp_user}]
+        [{block name="user_checkout_registration_next_step_top"}]
+            <div class="card bg-light cart-buttons">
+                <div class="card-body">
+                    <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-outline-dark prevStep submitButton largeButton" id="userBackStepTop">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
+                </div>
+            </div>
         [{/block}]
+    [{/if}]
 
-        [{block name="checkout_user_registration"}]
-            [{if !$oxcmp_user && $oView->getLoginOption() == 3}]
+    <div class="row">
+        [{if $oxcmp_user}]
+            [{block name="checkout_user_change"}]
+                <div class="col-12">
+                    [{include file="form/user_checkout_change.tpl"}]
+                </div>
+            [{/block}]
+        [{else}]
+            <div class="col-sm-4 order-sm-2">
+                [{block name="checkout_options_login"}]
+                    [{include file="form/login.tpl"}]
+                [{/block}]
+            </div>
+            <div class="col-sm-8 order-sm-1">
                 [{include file="form/user_checkout_registration.tpl"}]
-            [{/if}]
-        [{/block}]
+            </div>
+        [{/if}]
+    </div>
 
-        [{block name="checkout_user_change"}]
-            [{if $oxcmp_user}]
-                [{include file="form/user_checkout_change.tpl"}]
-            [{/if}]
-        [{/block}]
-    [{/block}]
     [{insert name="oxid_tracker" title=$template_title}]
 [{/capture}]
 


### PR DESCRIPTION
* Remove register options, only one page: left side registration, right side login
* Moved orderRemark from the shipping address form to its own card element
* Moved newsletter checkbox into the same card element as the remark textarea