### PR TITLE
breadcrumb: use schema.org instead of deprecated data-vocabulary

### DIFF
--- a/tpl/widget/breadcrumb.tpl
+++ b/tpl/widget/breadcrumb.tpl
@@ -9,8 +9,8 @@
                         <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item[{if $smarty.foreach.breadcrumb.last}] active[{/if}]">
                             <a href="[{if $sCrum.link}][{$sCrum.link}][{else}]#[{/if}]" class="breadcrumb-link" title="[{$sCrum.title|escape:'html'}]" itemprop="item">
                                 <span itemprop="name">[{$sCrum.title}]</span>
-                                <meta itemprop="position" content="[{$smarty.foreach.breadcrumb.iteration}]" />
                             </a>
+                            <meta itemprop="position" content="[{$smarty.foreach.breadcrumb.iteration}]" />
                         </li>
                     [{/foreach}]
                 [{/block}]

--- a/tpl/widget/breadcrumb.tpl
+++ b/tpl/widget/breadcrumb.tpl
@@ -1,14 +1,15 @@
 [{block name="dd_widget_breadcrumb"}]
     [{strip}]
         [{block name="dd_widget_breadcrumb_list_inner"}]
-            <ol id="breadcrumb" class="breadcrumb">
+            <ol id="breadcrumb" class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
                 [{block name="dd_widget_breadcrumb_list"}]
                     <li class="text-muted">[{oxmultilang ident="YOU_ARE_HERE"}]:</li>
 
                     [{foreach from=$oView->getBreadCrumb() item="sCrum" name="breadcrumb"}]
-                        <li itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="breadcrumb-item[{if $smarty.foreach.breadcrumb.last}] active[{/if}]">
-                            <a href="[{if $sCrum.link}][{$sCrum.link}][{else}]#[{/if}]" class="breadcrumb-link" title="[{$sCrum.title|escape:'html'}]" itemprop="url">
-                                <span itemprop="title">[{$sCrum.title}]</span>
+                        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item[{if $smarty.foreach.breadcrumb.last}] active[{/if}]">
+                            <a href="[{if $sCrum.link}][{$sCrum.link}][{else}]#[{/if}]" class="breadcrumb-link" title="[{$sCrum.title|escape:'html'}]" itemprop="item">
+                                <span itemprop="name">[{$sCrum.title}]</span>
+                                <meta itemprop="position" content="[{$smarty.foreach.breadcrumb.iteration}]" />
                             </a>
                         </li>
                     [{/foreach}]


### PR DESCRIPTION
data-vocabulary is deprecated and there will be a warning in google search console. Use schema.org instead.