### PR TITLE
Avoid empty div.row

### DIFF
--- a/tpl/page/list/list.tpl
+++ b/tpl/page/list/list.tpl
@@ -66,7 +66,7 @@
                                 </div>
                             [{/foreach}]
                         [{/if}]
-                        [{if $iSubCategoriesCount%4 == 0}]
+                        [{if $iSubCategoriesCount%4 == 0 and $iSubCategoriesCount neq 0}]
                             </div><div class="row">
                         [{/if}]
                         [{if $category->getIsVisible()}]


### PR DESCRIPTION
If $isubCategoriesCount is 0, we can reuse it as there is no content