### PR TITLE
Align delivery VAT to the right like other fields

### DIFF
--- a/tpl/page/checkout/inc/basketcontents.tpl
+++ b/tpl/page/checkout/inc/basketcontents.tpl
@@ -170,9 +170,9 @@
                         [{if $deliveryCost->getVatValue()}]
                         <tr>
                             [{if $oxcmp_basket->isProportionalCalculationOn() }]
-                                <th>[{oxmultilang ident="BASKET_TOTAL_PLUS_PROPORTIONAL_VAT" suffix="COLON"}]</th>
+                                <th class="text-right">[{oxmultilang ident="BASKET_TOTAL_PLUS_PROPORTIONAL_VAT" suffix="COLON"}]</th>
                             [{else}]
-                                <th>[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$deliveryCost->getVat()}]</th>
+                                <th class="text-right">[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$deliveryCost->getVat()}]</th>
                             [{/if}]
                             <td id="basketDeliveryVat" class="text-right">[{oxprice price=$deliveryCost->getVatValue() currency=$currency}]</td>
                         </tr>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1001186/82897756-6b0a5880-9f58-11ea-8a2c-8ed918d55011.png)


after:
![image](https://user-images.githubusercontent.com/1001186/82897767-6e054900-9f58-11ea-903c-ac3d7a0f7b96.png)
