### PR TITLE
fix regex syntax

### DIFF
--- a/build/vendor/jquery-bootstrap-validation/js/jqBootstrapValidation.js
+++ b/build/vendor/jquery-bootstrap-validation/js/jqBootstrapValidation.js
@@ -795,7 +795,7 @@
 			validemail: {
 				name: "Validemail",
 				type: "regex",
-				regex: "^(.+?)\@(.+)\.(.+)$",
+				regex: "(.+?)\@(.+)[.](.+)",
 				message: oWave.i18n.DD_FORM_VALIDATION_VALIDEMAIL
 			},
 			passwordagain: {


### PR DESCRIPTION
syntax of rexex was wrong because the point in a regex can not be simply escaped by using a single backslash inside a javavascript string because javascript itself will resolve `\.` to `.` so you need to use `[.]` or `\\\.` to match a point
aditionally  `$` and `^` doesn' t make sense because this string is beeing embeded into that charaters later anyway.

This fix will cause
`test@com` to fail
but
`test@example.com` will pass
which is what we need in my project and I guess this was the idea of the original author