### PR TITLE
Make salutation required if configured

### DIFF
--- a/tpl/form/fieldset/user_billing.tpl
+++ b/tpl/form/fieldset/user_billing.tpl
@@ -30,9 +30,10 @@
     [{assign var="oxuser__oxsal" value=$oxcmp_user->oxuser__oxsal->value}]
 [{/if}]
 <div class="form-group row">
-    <label class="col-lg-3[{if $oView->isFieldRequired(oxuser__oxsal)}] req[{/if}]" for="invadr_oxuser__oxsal">[{oxmultilang ident="TITLE"}]</label>
+    [{assign var="salutationRequired" value=$oView->isFieldRequired(oxuser__oxsal)}]
+    <label class="col-lg-3[{if $salutationRequired}] req[{/if}]" for="invadr_oxuser__oxsal">[{oxmultilang ident="TITLE"}]</label>
     <div class="col-lg-9">
-        [{include file="form/fieldset/salutation.tpl" name="invadr[oxuser__oxsal]" value=$oxuser__oxsal class="form-control" id="invadr_oxuser__oxsal"}]
+        [{include file="form/fieldset/salutation.tpl" name="invadr[oxuser__oxsal]" value=$oxuser__oxsal class="form-control" id="invadr_oxuser__oxsal" required=$salutationRequired}]
         <div class="help-block"></div>
     </div>
 </div>


### PR DESCRIPTION
At the moment you need to adapt the template if you want to make the salutation a required field. We already show the label as one of the required fields (in bold), but the select-element itself does not contain the `required` attribute.

Take also a look at the included file: https://github.com/OXID-eSales/wave-theme/blob/a0c2ee27eac91f54c3a2d207b74793cb72966fd4/tpl/form/fieldset/salutation.tpl#L4