### PR TITLE
Add template blocks to checkout process

### DIFF
--- a/tpl/form/user_checkout_noregistration.tpl
+++ b/tpl/form/user_checkout_noregistration.tpl
@@ -64,21 +64,23 @@
                         <h3 class="card-title">[{oxmultilang ident="SHIPPING_ADDRESS"}]</h3>
                     </div>
                     <div class="card-body">
-                        <div class="form-group">
-                            <div class="col-lg-9 offset-lg-3">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="blshowshipaddress" id="showShipAddress" [{if !$oView->showShipAddress()}]checked[{/if}] value="0"> [{oxmultilang ident="USE_BILLINGADDRESS_FOR_SHIPPINGADDRESS"}]
-                                    </label>
+                        [{block name="user_checkout_noregistration_shipping_address_body"}]
+                            <div class="form-group">
+                                <div class="col-lg-9 offset-lg-3">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="blshowshipaddress" id="showShipAddress" [{if !$oView->showShipAddress()}]checked[{/if}] value="0"> [{oxmultilang ident="USE_BILLINGADDRESS_FOR_SHIPPINGADDRESS"}]
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
 
-                        <div id="shippingAddress"[{if !$oView->showShipAddress()}] style="display: none;"[{/if}]>
-                            [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true}]
-                        </div>
+                            <div id="shippingAddress"[{if !$oView->showShipAddress()}] style="display: none;"[{/if}]>
+                                [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true}]
+                            </div>
 
-                        [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]
+                            [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]
+                        [{/block}]
                     </div>
                 </div>
             </div>

--- a/tpl/form/user_checkout_registration.tpl
+++ b/tpl/form/user_checkout_registration.tpl
@@ -65,22 +65,23 @@
                         <h3 class="card-title">[{oxmultilang ident="SHIPPING_ADDRESS"}]</h3>
                     </div>
                     <div class="card-body">
-                        <div class="form-group">
-                            <div class="col-lg-9 offset-lg-3">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="blshowshipaddress" id="showShipAddress" [{if !$oView->showShipAddress()}]checked[{/if}] value="0"> [{oxmultilang ident="USE_BILLINGADDRESS_FOR_SHIPPINGADDRESS"}]
-                                    </label>
+                        [{block name="user_checkout_registration_shipping_address_body"}]
+                            <div class="form-group">
+                                <div class="col-lg-9 offset-lg-3">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="blshowshipaddress" id="showShipAddress" [{if !$oView->showShipAddress()}]checked[{/if}] value="0"> [{oxmultilang ident="USE_BILLINGADDRESS_FOR_SHIPPINGADDRESS"}]
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
 
-                        <div id="shippingAddress" [{if !$oView->showShipAddress()}]style="display: none;"[{/if}]>
-                            [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true}]
-                        </div>
+                            <div id="shippingAddress" [{if !$oView->showShipAddress()}]style="display: none;"[{/if}]>
+                                [{include file="form/fieldset/user_shipping.tpl" noFormSubmit=true}]
+                            </div>
 
-                        [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]
-
+                            [{include file="form/fieldset/order_remark.tpl" blOrderRemark=true}]
+                        [{/block}]
                     </div>
                 </div>
             </div>

--- a/tpl/page/checkout/inc/basketcontents.tpl
+++ b/tpl/page/checkout/inc/basketcontents.tpl
@@ -11,7 +11,9 @@
     <input type="hidden" name="CustomError" value="basket">
 
     <div class="basket" id="basketcontents_list">
-        [{include file="page/checkout/inc/basketcontents_list.tpl"}]
+        [{block name="checkout_basketcontents_list"}]
+            [{include file="page/checkout/inc/basketcontents_list.tpl"}]
+        [{/block}]
     </div>
 
 </form>

--- a/tpl/page/checkout/inc/basketcontents_list.tpl
+++ b/tpl/page/checkout/inc/basketcontents_list.tpl
@@ -229,7 +229,7 @@
                         [{/block}]
                     </div>
                 </div>
-
+                [{block name="checkout_basketcontents_basketitem_end"}][{/block}]
                 <hr/>
             </li>
         [{/block}]

--- a/tpl/page/checkout/order.tpl
+++ b/tpl/page/checkout/order.tpl
@@ -103,12 +103,14 @@
                                         </h3>
                                     </div>
                                     <div class="card-body">
-                                        [{assign var="oDelAdress" value=$oView->getDelAddress()}]
-                                        [{if $oDelAdress}]
-                                            [{include file="widget/address/shipping_address.tpl" delivadr=$oDelAdress}]
-                                        [{else}]
-                                            [{include file="widget/address/billing_address.tpl"}]
-                                        [{/if}]
+                                        [{block name="checkout_order_address_inner"}]
+                                            [{assign var="oDelAdress" value=$oView->getDelAddress()}]
+                                            [{if $oDelAdress}]
+                                                [{include file="widget/address/shipping_address.tpl" delivadr=$oDelAdress}]
+                                            [{else}]
+                                                [{include file="widget/address/billing_address.tpl"}]
+                                            [{/if}]
+                                        [{/block}]
                                     </div>
                                 </div>
                             </form>


### PR DESCRIPTION
We needed these template blocks for the norisk click and collect module and I think they might be useful for other modules, too.