### PR TITLE
Add img-fluid class to manufacturer icon in product details

### DIFF
--- a/tpl/page/details/inc/productmain.tpl
+++ b/tpl/page/details/inc/productmain.tpl
@@ -310,7 +310,7 @@
                     [{block name="details_productmain_manufacturersicon"}]
                         <a href="[{$oManufacturer->getLink()}]" title="[{$oManufacturer->oxmanufacturers__oxtitle->value}]">
                             [{if $oManufacturer->oxmanufacturers__oxicon->value}]
-                                <img src="[{$oManufacturer->getIconUrl()}]" alt="[{$oManufacturer->oxmanufacturers__oxtitle->value}]">
+                                <img src="[{$oManufacturer->getIconUrl()}]" alt="[{$oManufacturer->oxmanufacturers__oxtitle->value}]" class="img-fluid">
                             [{/if}]
                         </a>
                         <span itemprop="brand" class="d-none">[{$oManufacturer->oxmanufacturers__oxtitle->value}]</span>


### PR DESCRIPTION
Add the `img-fluid` class to the manufacturer image in the `productmain` include.

This prevents the logo from overflowing the content area as in the following screenshot:

![screenshot_manufacturer_logo_overflow](https://user-images.githubusercontent.com/956513/103365634-cdb06d80-4ac0-11eb-97b2-def55d71352d.png)

To reproduce this, the logo size needs to be increased in the theme settings:

![screenshot_theme_settings](https://user-images.githubusercontent.com/956513/103365825-3f88b700-4ac1-11eb-8375-55352a37dc76.png)



