### PR TITLE
wrap forgot_email into a block to be overriden

### DIFF
--- a/tpl/page/account/forgotpwd.tpl
+++ b/tpl/page/account/forgotpwd.tpl
@@ -33,6 +33,7 @@
         </form>
     [{else}]
         [{if $oView->getForgotEmail()}]
+            [{block name="forgot_email"}]
             <div class="alert alert-info">[{oxmultilang ident="PASSWORD_WAS_SEND_TO"}] [{$oView->getForgotEmail()}]</div>
             <div class="bar">
                 <form action="[{$oViewConf->getSelfActionLink()}]" name="forgotpwd" method="post">
@@ -45,6 +46,7 @@
                     </div>
                  </form>
              </div>
+             [{/block}]
         [{else}]
             [{include file="form/forgotpwd_email.tpl"}]
         [{/if}]


### PR DESCRIPTION
Useful when one needs to deal with "user enumeration" security issue https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
