### PR TITLE
fixed list title

### DIFF
--- a/tpl/page/list/list.tpl
+++ b/tpl/page/list/list.tpl
@@ -29,7 +29,7 @@
         <div class="page-header">
             [{assign var='rsslinks' value=$oView->getRssLinks()}]
             <h1 class="h1">
-                [{$actCategory->getTitle()}]
+                [{$oView->getTitle()}]
                 [{if $rsslinks.activeCategory}]
                     <a class="rss" id="rssActiveCategory" aria-label="RSS Current Category" href="[{$rsslinks.activeCategory.link}]" title="[{$rsslinks.activeCategory.title}]" target="_blank">
                         <i class="fas fa-rss"></i>


### PR DESCRIPTION
Fixed category title. 
$oView->getActiveCategory() is not set when reusing template for other lists, f.e. tags.

Compare to Flow theme: https://github.com/OXID-eSales/flow_theme/blob/master/tpl/page/list/list.tpl#L35