### PR TITLE
Fix for typo "aarr" (instead of "arr") in theme.php

### DIFF
--- a/theme.php
+++ b/theme.php
@@ -209,7 +209,7 @@ $aTheme = array(
         array(
             'group' => 'images',
             'name' => 'aDetailImageSizes',
-            'type' => 'aarr',
+            'type' => 'arr',
             'value' => array(
                 'oxpic1' => '540*340',
                 'oxpic2' => '540*340',


### PR DESCRIPTION
There is a typo in the "aDetailImageSizes" section in theme.php:

```
        array(
            'group' => 'images',
            'name' => 'aDetailImageSizes',
            'type' => 'aarr',
            ...
```

This prevents images for the article detail pages from being generated correctly.

I fixed it by changing "aarr" to "arr".